### PR TITLE
feat(react-hook-form-v2): update the base field hints icon alignment

### DIFF
--- a/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/Hints.tsx
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/Hints.tsx
@@ -6,11 +6,18 @@ import {
   ExclamationCircleFilledIcon,
   TimesCircleFilledIcon,
 } from '@mezzanine-ui/icons';
+import { cx } from '@mezzanine-ui/react';
 import { Severity } from '@mezzanine-ui/system/severity';
 import classes from './index.module.scss';
 
 interface HintsProps {
-  hints: string[] | { severity: Severity | 'info'; text: string }[];
+  hints:
+    | string[]
+    | {
+        severity: Severity | 'info';
+        text: string;
+        iconAlignment?: 'top' | 'bottom' | 'center';
+      }[];
 }
 
 const hintIcons = {
@@ -53,8 +60,14 @@ const Hints: FC<HintsProps> = ({ hints }) => {
           );
         }
 
+        const alignment = hint.iconAlignment || 'top';
+        const alignmentClass = classes[alignment];
+
         return (
-          <div key={hint.text} className={classes.hintWrapper}>
+          <div
+            key={hint.text}
+            className={cx(classes.hintWrapper, alignmentClass)}
+          >
             <Icon
               icon={hintIcons[hint.severity]}
               size={16}

--- a/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/index.module.scss
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/index.module.scss
@@ -71,8 +71,19 @@
 
   .hintWrapper {
     display: flex;
-    align-items: center;
     justify-content: flex-start;
     gap: 4px;
+
+    &.top {
+      align-items: start;
+    }
+
+    &.bottom {
+      align-items: end;
+    }
+
+    &.center {
+      align-items: center;
+    }
   }
 }

--- a/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/index.tsx
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/BaseField/index.tsx
@@ -35,7 +35,13 @@ export interface BaseFieldProps {
   width?: number;
   errorMsgRender?: ErrorMessageFn;
   horizontal?: boolean;
-  hints?: string[] | { severity: Severity | 'info'; text: string }[];
+  hints?:
+    | string[]
+    | {
+        severity: Severity | 'info';
+        text: string;
+        iconAlignment?: 'top' | 'bottom' | 'center';
+      }[];
 }
 
 export const BaseField: FC<BaseFieldProps> = ({


### PR DESCRIPTION
* Update the base field hints icon alignment
* Add icon alignment props and set the default to top

* view: ![截圖 2025-04-24 上午10 57 07](https://github.com/user-attachments/assets/ccd06c0b-ef36-42c1-8a85-55ce38827c4b)
 