### PR TITLE
feat(ui-admin-components): add admin table loading text

### DIFF
--- a/apps/mezzanine-ui-admin-components/src/AdminTable/AdminTable.stories.tsx
+++ b/apps/mezzanine-ui-admin-components/src/AdminTable/AdminTable.stories.tsx
@@ -271,3 +271,53 @@ export const CustomizedEmpty: Story = {
     return <AdminTable {...args} />;
   },
 };
+
+export const AdminTableEN: Story = {
+  args: {
+    ...Default.args,
+    loadingTip: 'Loading...',
+    columns: [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+      },
+      {
+        title: 'Account',
+        dataIndex: 'account',
+      },
+      {
+        title: 'Phone',
+        dataIndex: 'phone',
+      },
+    ],
+    actions: (source) => [
+      {
+        text: 'Edit',
+        onClick: () => {
+          action('Edit')(source);
+        },
+      },
+      {
+        text: 'Delete',
+        danger: true,
+        onClick: () => {
+          action('Delete')(source);
+        },
+      },
+    ],
+    emptyProps: {
+      children: 'No data found',
+    },
+    pagination: {
+      current: 1,
+      total: dataSource.length,
+      onChange: action('onChange'),
+      options: {
+        pageSize: 4,
+        renderPaginationSummary: (start, end) =>
+          `Showing ${start} to ${end} of ${dataSource.length} entries`,
+      },
+    },
+  },
+  render: Default.render,
+};

--- a/apps/mezzanine-ui-admin-components/src/AdminTable/index.tsx
+++ b/apps/mezzanine-ui-admin-components/src/AdminTable/index.tsx
@@ -101,6 +101,10 @@ export type AdminTableProps<T extends TableDataSourceWithID> = {
    * 切換 tab 時觸發
    */
   onTabChange?: (tabId: Key) => void;
+  /**
+   * 自定義 loading 提示文字
+   */
+  loadingTip?: string;
 };
 
 /**
@@ -130,6 +134,7 @@ export const AdminTable = <T extends TableDataSourceWithID>({
   tabs,
   activeTabId,
   onTabChange,
+  loadingTip,
 }: AdminTableProps<T>): JSX.Element => {
   const columns = useMemo(
     (): TableColumn<T>[] =>
@@ -188,6 +193,7 @@ export const AdminTable = <T extends TableDataSourceWithID>({
         scroll={scroll}
         scrollContainerClassName={scrollContainerClassName}
         loading={loading}
+        loadingTip={loadingTip}
         pagination={pagination}
         draggable={draggable}
         expandable={expandable}


### PR DESCRIPTION
* Open the admin table's loading tips props settings.
* Add English props settings for the admin table.
* related to https://github.com/Mezzanine-UI/components/issues/4)