### PR TITLE
feat(react-hook-form-v2): enhance form component props and configuration

### DIFF
--- a/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/FormFieldsWrapper.stories.tsx
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/FormFieldsWrapper.stories.tsx
@@ -358,3 +358,129 @@ export const WithStep: Story = {
     );
   },
 };
+
+const modelTextEN = {
+  headerText: 'Cancel',
+  bodyText: 'Are you sure you want to cancel?',
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
+};
+
+const ENSteps = [
+  {
+    id: 'STEP1',
+    name: 'Step 1',
+  },
+  {
+    id: 'STEP2',
+    name: 'Step 2',
+  },
+  {
+    id: 'STEP3',
+    name: 'Step 3',
+  },
+];
+
+export const WithENContent: Story = {
+  args: {
+    children: undefined,
+  },
+  parameters: {
+    controls: { include: [] },
+  },
+  render: function Render() {
+    const methods = useForm<DemoFormValues>({
+      defaultValues: {
+        input1: '',
+        input2: '',
+        input3: '',
+      },
+    });
+
+    const [activeStep, setActiveStep] = useState<number>(0);
+
+    const fieldComponent = useMemo(() => {
+      switch (activeStep) {
+        case 0:
+          return (
+            <InputField
+              key={activeStep}
+              label="input1"
+              registerName="input1"
+              required
+              placeholder="Input 1"
+            />
+          );
+
+        case 1:
+          return (
+            <InputField
+              key={activeStep}
+              label="input2"
+              registerName="input2"
+              required
+              placeholder="Input 2"
+            />
+          );
+
+        case 2:
+          return (
+            <InputField
+              key={activeStep}
+              label="input3"
+              registerName="input3"
+              required
+              placeholder="Input 3"
+            />
+          );
+
+        default:
+          return null;
+      }
+    }, [activeStep]);
+
+    return (
+      <FormFieldsWrapper
+        methods={methods}
+        haveFooter
+        onSubmit={async (values) => {
+          action('onSubmit')(values);
+        }}
+        submitButtonText="Submit"
+        disableSubmitButton={(values) =>
+          !values.input1 || !values.input2 || !values.input3
+        }
+        onCancel={async (values) => {
+          action('onCancel')(values);
+        }}
+        cancelButtonText="Cancel"
+        onClickAction={async (values) => {
+          action('onClickAction')(values);
+        }}
+        actionButtonText="Left Text"
+        steps={ENSteps}
+        activeStep={activeStep}
+        setActiveStep={(s) => {
+          setActiveStep(s);
+        }}
+        previousStepButtonText="Previous"
+        nextStepButtonText="Next"
+        disableNextButton={({ values, activeStep }) => {
+          switch (activeStep) {
+            case 0:
+              return !values.input1;
+
+            case 1:
+              return !values.input2;
+
+            default:
+              return false;
+          }
+        }}
+        modelText={modelTextEN}
+      >
+        <StoryWrapper>{fieldComponent}</StoryWrapper>
+      </FormFieldsWrapper>
+    );
+  },
+};

--- a/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/FormFooter/index.tsx
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/FormFooter/index.tsx
@@ -11,6 +11,13 @@ import {
 import { FieldValues, useWatch } from 'react-hook-form';
 import classes from './index.module.scss';
 
+const defaultModelText = {
+  headerText: '確認取消',
+  bodyText: '取消不會儲存內容，確定取消？',
+  confirmText: '確認取消',
+  cancelText: '取消',
+};
+
 export interface FormFooterProps<T extends FieldValues = FieldValues> {
   footerClassName?: string;
   expanded?: boolean;
@@ -38,6 +45,14 @@ export interface FormFooterProps<T extends FieldValues = FieldValues> {
     values: T;
     activeStep: number;
   }) => boolean;
+  previousStepButtonText?: string;
+  nextStepButtonText?: string;
+  modelText?: {
+    headerText?: string;
+    bodyText?: string;
+    confirmText?: string;
+    cancelText?: string;
+  };
 }
 
 const FormFooter = <T extends FieldValues>({
@@ -61,6 +76,9 @@ const FormFooter = <T extends FieldValues>({
   activeStep,
   setActiveStep,
   disableNextButton,
+  previousStepButtonText = '上一步',
+  nextStepButtonText = '下一步',
+  modelText = defaultModelText,
 }: FormFooterProps<T>) => {
   const [acting, setActing] = useState<boolean>(false);
   const [cancelConfirmModalOpened, setCancelConfirmModalOpened] =
@@ -117,7 +135,7 @@ const FormFooter = <T extends FieldValues>({
                 setActiveStep?.((activeStep ?? 0) - 1);
               }}
             >
-              上一步
+              {previousStepButtonText}
             </Button>
           ) : (
             cancelButtonText &&
@@ -154,7 +172,7 @@ const FormFooter = <T extends FieldValues>({
                 setActiveStep?.((activeStep ?? 0) + 1);
               }}
             >
-              下一步
+              {nextStepButtonText}
             </Button>
           ) : (
             <Button
@@ -180,11 +198,11 @@ const FormFooter = <T extends FieldValues>({
         }}
         open={cancelConfirmModalOpened}
       >
-        <ModalHeader showSeverityIcon>確認取消</ModalHeader>
-        <ModalBody>取消不會儲存內容，確定取消？</ModalBody>
+        <ModalHeader showSeverityIcon>{modelText.headerText}</ModalHeader>
+        <ModalBody>{modelText.bodyText}</ModalBody>
         <ModalActions
-          cancelText="取消"
-          confirmText="確認取消"
+          cancelText={modelText.cancelText}
+          confirmText={modelText.confirmText}
           cancelButtonProps={{
             type: 'button',
             size: 'large',

--- a/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/index.tsx
+++ b/apps/mezzanine-ui-react-hook-form-v2/src/FormFieldsWrapper/index.tsx
@@ -49,6 +49,14 @@ export interface FormFieldsWrapperProps<T extends FieldValues = FieldValues>
   onClickAction?: (values: T) => Promise<void>;
   onCancel?: (values: T) => Promise<void>;
   cancelNeedConfirm?: boolean;
+  previousStepButtonText?: string;
+  nextStepButtonText?: string;
+  modelText?: {
+    headerText?: string;
+    bodyText?: string;
+    confirmText?: string;
+    cancelText?: string;
+  };
 }
 
 export const FormFieldsWrapper = <T extends FieldValues>({
@@ -79,6 +87,9 @@ export const FormFieldsWrapper = <T extends FieldValues>({
   onClickAction,
   onCancel,
   cancelNeedConfirm = true,
+  previousStepButtonText,
+  nextStepButtonText,
+  modelText,
   ...other
 }: FormFieldsWrapperProps<T>) => {
   const layoutStyleVar = useMemo(
@@ -130,6 +141,9 @@ export const FormFieldsWrapper = <T extends FieldValues>({
             activeStep={activeStep}
             setActiveStep={setActiveStep}
             disableNextButton={disableNextButton}
+            previousStepButtonText={previousStepButtonText}
+            nextStepButtonText={nextStepButtonText}
+            modelText={modelText}
           />
         )}
       </form>


### PR DESCRIPTION
* Add default model text configuration
* Add step navigation button text customization
* Add English form field example in storybook
* related to #5 
* view: 
  * ![截圖 2025-04-25 上午10 29 57](https://github.com/user-attachments/assets/0e0fc969-8899-4afe-8cad-5517487b926f)
  * ![截圖 2025-04-25 上午10 30 07](https://github.com/user-attachments/assets/7e6e6293-59f6-4ef2-b57f-4c8f285e2caa)
