### PR TITLE
feat(ui-admin-component): add UploadImagesWall component translate component

### DIFF
--- a/apps/mezzanine-ui-admin-components/src/UploadImagesWall/ImagesWallModal/index.tsx
+++ b/apps/mezzanine-ui-admin-components/src/UploadImagesWall/ImagesWallModal/index.tsx
@@ -8,7 +8,7 @@ import { ImagesWallModalFormValues } from './typing';
 
 interface ImagesWallModalProps {
   open: boolean;
-  actionText: string;
+  actionStatus: 'edit' | 'create' | '';
   temporaryImages: UploadImagesWallFormValues[];
   limit: number;
   maxLength: number;
@@ -17,11 +17,22 @@ interface ImagesWallModalProps {
   onConfirm: (values: UploadImagesWallFormValues[]) => void;
   upload: (file: File) => Promise<{ id: string }>;
   objectFit: 'cover' | 'contain';
+  fileExceededLimit?: (file: File, limit: number) => string;
+  fileUploadFailed?: (file: File) => string;
+  uploadedImagesText?: (currentIndex: number, maxLength: number) => string;
+  currentImageLength?: (currentSize: number, maxLength: number) => string;
+  editModalHeaderText?: string;
+  createModalHeaderText?: string;
+  editModalConfirmText?: string;
+  createModalConfirmText?: string;
+  emptyGalleryText?: string;
+  modalActionCancelText?: string;
+  modalActionUploadText?: string;
 }
 
 const ImagesWallModal: FC<ImagesWallModalProps> = ({
   open,
-  actionText,
+  actionStatus,
   temporaryImages,
   limit,
   maxLength,
@@ -30,6 +41,17 @@ const ImagesWallModal: FC<ImagesWallModalProps> = ({
   onConfirm,
   upload,
   objectFit,
+  fileExceededLimit,
+  fileUploadFailed,
+  uploadedImagesText,
+  emptyGalleryText,
+  modalActionCancelText,
+  modalActionUploadText,
+  currentImageLength,
+  editModalHeaderText,
+  createModalHeaderText,
+  editModalConfirmText,
+  createModalConfirmText,
 }) => {
   const methods = useForm<ImagesWallModalFormValues>();
 
@@ -42,7 +64,7 @@ const ImagesWallModal: FC<ImagesWallModalProps> = ({
     >
       <FormFieldsWrapper methods={methods}>
         <ModalMain
-          actionText={actionText}
+          actionStatus={actionStatus}
           temporaryImages={temporaryImages}
           limit={limit}
           maxLength={maxLength}
@@ -51,6 +73,19 @@ const ImagesWallModal: FC<ImagesWallModalProps> = ({
           onConfirm={onConfirm}
           upload={upload}
           objectFit={objectFit}
+          texts={{
+            fileExceededLimit,
+            fileUploadFailed,
+            uploadedImagesText,
+            currentImageLength,
+            emptyGalleryText,
+            modalActionCancelText,
+            modalActionUploadText,
+            editModalHeaderText,
+            createModalHeaderText,
+            editModalConfirmText,
+            createModalConfirmText,
+          }}
         />
       </FormFieldsWrapper>
     </Modal>

--- a/apps/mezzanine-ui-admin-components/src/UploadImagesWall/UploadImagesWall.stories.tsx
+++ b/apps/mezzanine-ui-admin-components/src/UploadImagesWall/UploadImagesWall.stories.tsx
@@ -64,6 +64,7 @@ export const Default: Story = {
 export const CustomTexts: Story = {
   args: {
     ...Default.args,
+    showMaxImageLengthNotice: false,
     hints: ['File format: JPG or PNG only', 'File size: cannot exceed 20 MB'],
     texts: {
       fileExceededLimit: (file: File, limit: number) =>
@@ -86,7 +87,7 @@ export const CustomTexts: Story = {
       editModalConfirmText: 'Confirm edit',
       createModalHeaderText: 'Create image wall',
       createModalConfirmText: 'Confirm create',
-      emptyGalleryText: 'No images yet',
+      emptyGalleryText: 'Not images yet',
       modalActionCancelText: 'Cancel',
       modalActionUploadText: 'Add image',
       currentImageLength: (currentSize: number, maxLength: number) =>

--- a/apps/mezzanine-ui-admin-components/src/UploadImagesWall/UploadImagesWall.stories.tsx
+++ b/apps/mezzanine-ui-admin-components/src/UploadImagesWall/UploadImagesWall.stories.tsx
@@ -60,3 +60,44 @@ export const Default: Story = {
     );
   },
 };
+
+export const CustomTexts: Story = {
+  args: {
+    ...Default.args,
+    hints: ['File format: JPG or PNG only', 'File size: cannot exceed 20 MB'],
+    texts: {
+      fileExceededLimit: (file: File, limit: number) =>
+        `${file.name} upload failed (file size exceeds ${limit} MB)`,
+      fileUploadFailed: (file: File) =>
+        `${file.name} upload failed (invalid file format)`,
+      maxImageLengthNotice: (maxLength: number) =>
+        `Maximum ${maxLength} images`,
+      deleteWallDialogTitle: 'Confirm to delete this image wall?',
+      deleteWallDialogChildren:
+        'The image wall will be removed, and all image content within it will also be deleted. This action cannot be undone.',
+      deleteWallDialogCancelText: 'Cancel',
+      deleteWallDialogConfirmText: 'Delete image wall',
+      deleteWallActionText: 'Delete image wall',
+      editWallActionText: 'Edit image wall',
+      createWallActionText: 'Create image wall',
+    },
+    modalTexts: {
+      editModalHeaderText: 'Edit image wall',
+      editModalConfirmText: 'Confirm edit',
+      createModalHeaderText: 'Create image wall',
+      createModalConfirmText: 'Confirm create',
+      emptyGalleryText: 'No images yet',
+      modalActionCancelText: 'Cancel',
+      modalActionUploadText: 'Add image',
+      currentImageLength: (currentSize: number, maxLength: number) =>
+        `Uploaded images: ${currentSize}/${maxLength}`,
+      fileExceededLimit: (file: File, limit: number) =>
+        `${file.name} upload failed (file size exceeds ${limit} MB)`,
+      fileUploadFailed: (file: File) =>
+        `${file.name} upload failed (invalid file format)`,
+      uploadedImagesText: (currentIndex: number, maxLength: number) =>
+        `${currentIndex}/${maxLength}`,
+    },
+  },
+  render: Default.render,
+};

--- a/apps/mezzanine-ui-admin-components/src/UploadImagesWall/index.tsx
+++ b/apps/mezzanine-ui-admin-components/src/UploadImagesWall/index.tsx
@@ -48,6 +48,10 @@ export interface UploadImagesWallProps {
    */
   objectFit?: 'contain' | 'cover';
   /**
+   * 是否顯示圖片上限的文字
+   */
+  showMaxImageLengthNotice?: boolean;
+  /**
    * 文字設定
    * * fileExceededLimit: 檔案大小超過限制時的文字
    * * fileUploadFailed: 檔案上傳失敗時的文字
@@ -131,6 +135,7 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
   setFileUrl,
   objectFit = 'cover',
   texts = {},
+  showMaxImageLengthNotice = true,
   modalTexts = {},
 }) => {
   const [loading, setLoading] = useState<boolean>(false);
@@ -257,13 +262,15 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
   return (
     <>
       <div className={classes.root}>
-        <Typography
-          variant="h6"
-          color="text-secondary"
-          className={classes.limitHint}
-        >
-          {mergedTextsContent.maxImageLengthNotice(maxLength)}
-        </Typography>
+        {showMaxImageLengthNotice && (
+          <Typography
+            variant="h6"
+            color="text-secondary"
+            className={classes.limitHint}
+          >
+            {mergedTextsContent.maxImageLengthNotice(maxLength)}
+          </Typography>
+        )}
         {fields.length > 0 ? (
           <div className={classes.imagesSection}>
             <div className={classes.wallImagesWrapper}>

--- a/apps/mezzanine-ui-admin-components/src/UploadImagesWall/index.tsx
+++ b/apps/mezzanine-ui-admin-components/src/UploadImagesWall/index.tsx
@@ -47,7 +47,76 @@ export interface UploadImagesWallProps {
    * 圖片 object-fit
    */
   objectFit?: 'contain' | 'cover';
+  /**
+   * 文字設定
+   * * fileExceededLimit: 檔案大小超過限制時的文字
+   * * fileUploadFailed: 檔案上傳失敗時的文字
+   * * maxImageLengthNotice: 圖片上限文字
+   * * deleteWallDialogTitle: 刪除圖輯彈窗標題
+   * * deleteWallDialogChildren: 刪除圖輯彈窗內容
+   * * deleteWallDialogCancelText: 刪除圖輯彈窗取消按鈕文字
+   * * deleteWallDialogConfirmText: 刪除圖輯彈窗確認按鈕文字
+   * * deleteWallActionText: 刪除圖輯按鈕文字
+   * * editWallActionText: 編輯圖輯按鈕文字
+   * * createWallActionText: 創建圖輯按鈕文字
+   */
+  texts?: {
+    fileExceededLimit?: (file: File, limit: number) => string;
+    fileUploadFailed?: (file: File) => string;
+    maxImageLengthNotice?: (maxLength: number) => string;
+    deleteWallDialogTitle?: string;
+    deleteWallDialogChildren?: string;
+    deleteWallDialogCancelText?: string;
+    deleteWallDialogConfirmText?: string;
+    deleteWallActionText?: string;
+    editWallActionText?: string;
+    createWallActionText?: string;
+  };
+  /**
+   * 圖輯彈窗文字設定
+   * * fileExceededLimit: 檔案大小超過限制時的文字
+   * * fileUploadFailed: 檔案上傳失敗時的文字
+   * * uploadedImagesText: 目前上傳圖片數量文字
+   * * currentImageLength: 目前圖片數量文字
+   * * editModalHeaderText: 編輯圖輯彈窗標題
+   * * createModalHeaderText: 創建圖輯彈窗標題
+   * * editModalConfirmText: 編輯圖輯彈窗確認按鈕文字
+   * * createModalConfirmText: 創建圖輯彈窗確認按鈕文字
+   * * emptyGalleryText: 目前尚無資料文字
+   * * modalActionCancelText: 取消按鈕文字
+   * * modalActionUploadText: 新增圖片按鈕文字
+   */
+  modalTexts?: {
+    fileExceededLimit?: (file: File, limit: number) => string;
+    fileUploadFailed?: (file: File) => string;
+    uploadedImagesText?: (currentIndex: number, maxLength: number) => string;
+    currentImageLength?: (currentSize: number, maxLength: number) => string;
+    editModalHeaderText?: string;
+    createModalHeaderText?: string;
+    editModalConfirmText?: string;
+    createModalConfirmText?: string;
+    emptyGalleryText?: string;
+    modalActionCancelText?: string;
+    modalActionUploadText?: string;
+  };
 }
+
+const defaultTexts = {
+  fileExceededLimit: (file: File, limit: number) =>
+    `${file.name} 上傳失敗 (檔案大小超過 ${limit} MB)`,
+  fileUploadFailed: (file: File) => `${file.name} 上傳失敗（檔案格式錯誤）`,
+  maxImageLengthNotice: (maxLength: number) => `圖片上限 ${maxLength} 張`,
+  currentImageLength: (currentSize: number, maxLength: number) =>
+    `已上傳圖片：${currentSize}/${maxLength}`,
+  deleteWallDialogTitle: '確認刪除此圖輯？',
+  deleteWallDialogChildren:
+    '圖輯將被移除，圖輯中的所有影像內容也將一併刪除，此動作無法復原。',
+  deleteWallDialogCancelText: '取消',
+  deleteWallDialogConfirmText: '刪除圖輯',
+  deleteWallActionText: '刪除圖輯',
+  editWallActionText: '編輯圖輯',
+  createWallActionText: '創建圖輯',
+};
 
 /**
  * 後台圖輯上傳器
@@ -61,16 +130,18 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
   upload,
   setFileUrl,
   objectFit = 'cover',
+  texts = {},
+  modalTexts = {},
 }) => {
   const [loading, setLoading] = useState<boolean>(false);
   const { openDialog } = useDialog();
 
   const [modalState, setModalState] = useState<{
     open: boolean;
-    actionText: string;
+    actionStatus: 'edit' | 'create' | '';
   }>({
     open: false,
-    actionText: '',
+    actionStatus: '',
   });
 
   const { fields, replace } = useFieldArray({
@@ -91,6 +162,14 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
 
   const MAX_SIZE = useMemo(() => limit * 1024 * 1024, [limit]); // limit MB
 
+  const mergedTextsContent = useMemo(
+    () => ({
+      ...defaultTexts,
+      ...texts,
+    }),
+    [texts],
+  );
+
   const onUpload = useCallback(
     async (files: File[]) => {
       await files
@@ -100,9 +179,12 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
             () =>
               new Promise((resolve) => {
                 setTimeout(() => {
-                  Message.error(
-                    `${f.name} 上傳失敗 (檔案大小超過 ${limit} MB)`,
+                  const errorMessage = mergedTextsContent.fileExceededLimit(
+                    f,
+                    limit,
                   );
+
+                  Message.error(errorMessage);
                   resolve();
                 }, 10);
               }),
@@ -125,48 +207,49 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
           setLoading(false);
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
-          Message.error(`${f.name} 上傳失敗（檔案格式錯誤）`);
+          const errorMessage = mergedTextsContent.fileUploadFailed(f);
+
+          Message.error(errorMessage);
         }
       });
 
       setModalState({
         open: true,
-        actionText: '創建',
+        actionStatus: 'create',
       });
     },
-    [MAX_SIZE, limit, upload],
+    [MAX_SIZE, limit, upload, mergedTextsContent],
   );
 
   const onClose = useCallback(() => {
     setTemporaryImages([]);
     setModalState({
       open: false,
-      actionText: '',
+      actionStatus: '',
     });
   }, []);
 
   const onDeleteWall = useCallback(async () => {
     const isConfirm = await openDialog({
       severity: 'error',
-      title: '確認刪除此圖輯？',
-      children:
-        '圖輯將被移除，圖輯中的所有影像內容也將一併刪除，此動作無法復原。',
-      cancelText: '取消',
+      title: mergedTextsContent.deleteWallDialogTitle,
+      children: mergedTextsContent.deleteWallDialogChildren,
+      cancelText: mergedTextsContent.deleteWallDialogCancelText,
       cancelButtonProps: {
         danger: false,
       },
-      confirmText: '刪除圖輯',
+      confirmText: mergedTextsContent.deleteWallDialogConfirmText,
     });
 
     if (isConfirm) {
       replace([]);
     }
-  }, [openDialog, replace]);
+  }, [openDialog, replace, mergedTextsContent]);
 
   const onEditWall = useCallback(() => {
     setModalState({
       open: true,
-      actionText: '編輯',
+      actionStatus: 'edit',
     });
     setTemporaryImages(imagesWallValue);
   }, [imagesWallValue]);
@@ -179,7 +262,7 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
           color="text-secondary"
           className={classes.limitHint}
         >
-          {`圖片上限 ${maxLength} 張`}
+          {mergedTextsContent.maxImageLengthNotice(maxLength)}
         </Typography>
         {fields.length > 0 ? (
           <div className={classes.imagesSection}>
@@ -203,7 +286,7 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
                 size="large"
                 onClick={onDeleteWall}
               >
-                刪除圖輯
+                {mergedTextsContent.deleteWallActionText}
               </Button>
               <Button
                 type="button"
@@ -212,7 +295,7 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
                 prefix={<Icon icon={EditIcon} />}
                 onClick={onEditWall}
               >
-                編輯圖輯
+                {mergedTextsContent.editWallActionText}
               </Button>
             </div>
           </div>
@@ -228,7 +311,7 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
               loading={loading}
               disabled={disabled}
             >
-              創建圖輯
+              {mergedTextsContent.createWallActionText}
             </UploadButton>
             {hints && hints.length > 0 && <Hints hints={hints} />}
           </>
@@ -236,7 +319,6 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
       </div>
       <ImagesWallModal
         open={modalState.open}
-        actionText={modalState.actionText}
         temporaryImages={temporaryImages}
         limit={limit}
         maxLength={maxLength}
@@ -248,6 +330,8 @@ export const UploadImagesWall: FC<UploadImagesWallProps> = ({
         }}
         upload={upload}
         objectFit={objectFit}
+        actionStatus={modalState.actionStatus}
+        {...modalTexts}
       />
     </>
   );


### PR DESCRIPTION
## feat(admin-components): Add i18n support for UploadImagesWall

### Changes
- Add text customization support for all component content
- Add new story example with English translations
- Support custom text for:
  - Upload messages
  - Modal content
  - Dialog content
  - Button labels
- Add showMaxImageLengthNotice prop to control max length notice visibility
- Related to #6 

### Example
Added new story with English translations to demonstrate usage:
```typescript
<UploadImagesWall
  texts={{
    deleteWallActionText: 'Delete image wall',
    editWallActionText: 'Edit image wall'
  }}
  modalTexts={{
    editModalHeaderText: 'Edit image wall',
    createModalHeaderText: 'Create image wall'
  }}
/>
```

### view
* ![截圖 2025-04-25 下午5 49 45](https://github.com/user-attachments/assets/eb2be32d-cb9f-4adb-9271-7804f45ec5f2)
* ![截圖 2025-04-25 下午5 49 32](https://github.com/user-attachments/assets/5d311059-cff6-48d3-9226-8d04c2f6101f)
* ![截圖 2025-04-25 下午5 49 08](https://github.com/user-attachments/assets/f59a173a-ccc8-4694-ae4e-278658c4e8d9)
* ![截圖 2025-04-25 下午5 49 20](https://github.com/user-attachments/assets/acf50fe0-b620-4baa-b79f-c691bbbe4436)
* ![截圖 2025-04-25 下午5 49 25](https://github.com/user-attachments/assets/a89e1a4f-7f49-46cc-aa39-34ce859d749c)
* ![截圖 2025-04-25 下午5 48 57](https://github.com/user-attachments/assets/c22359d3-a3de-4696-b213-e111b99199bf)